### PR TITLE
Test out the new cd-ci-glue library for updating the docker hub description.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,27 @@ sudo: required
 services:
   - docker
 
+env:
+  matrix:
+    - DIST=lenny
+    - DIST=etch
+    - DIST=squeeze
+
 before_install:
-   - if [[ "${TRAVIS_BRANCH}" == "master" ]] ; then
-       echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin ;
-     fi
+   - source <(curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash)
      
 script:
-   - for DIST in lenny etch squeeze ; do 
-       make DEBIAN_VERSION=${DIST} && 
-       if [[ "${TRAVIS_BRANCH}" == "master" ]] ; then
-         make DEBIAN_VERSION=${DIST} push ;
-       fi
+       make DEBIAN_VERSION=${DIST} \
+       && is_travis_master_push    \
+       && echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin \
+       && make DEBIAN_VERSION=${DIST} push
      done
+
+jobs:
+  include:
+    - stage: Publish project description to Docker hub
+      env: DIST
+      script:
+        - true
+      after_success:
+        - is_travis_master_push && dockerhub_set_description madworx/debian-archive README.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ env:
     - DIST=squeeze
 
 script:
-   - make --version || true ; source <(curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash) && \
-     make DEBIAN_VERSION=${DIST} && \
+   - make --version || true ; set ; source <(curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash) && \
+     set ; make DEBIAN_VERSION=${DIST} && \
      is_travis_master_push && \
      echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin && \
      make DEBIAN_VERSION=${DIST} push

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,16 @@
-language: c
-
-sudo: required
-
-services:
-  - docker
-
 env:
   matrix:
     - DIST=lenny
     - DIST=etch
     - DIST=squeeze
 
+language: c
+sudo: required
+services:
+  - docker
+
 before_install:
-   - source <(curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash > /tmp/cd-ci-glue.bash)
+   - source <(curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash)
    
 script:
    - (make DEBIAN_VERSION=${DIST} && 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ env:
     - DIST=squeeze
 
 script:
-   - source <(curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash) && \
-     ( make DEBIAN_VERSION=${DIST} && \
-       is_travis_master_push && \
-       echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin && \
+   - source <(curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash) && 
+     ( make DEBIAN_VERSION=${DIST} && 
+       is_travis_master_push && 
+       echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin && 
        make DEBIAN_VERSION=${DIST} push ) || true
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - DIST=squeeze
 
 script:
-   - source <(curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash) && \
+   - make --version || true ; source <(curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash) && \
      make DEBIAN_VERSION=${DIST} && \
      is_travis_master_push && \
      echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin && \
@@ -23,7 +23,5 @@ jobs:
     - stage: Publish project description to Docker hub
       env: DIST
       script:
-        - true
-      after_success:
         - source <(curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash) && \
           is_travis_master_push && dockerhub_set_description madworx/debian-archive README.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,21 +12,20 @@ env:
     - DIST=squeeze
 
 before_install:
-   - curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash > /tmp/cd-ci-glue.bash
+   - curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash > /tmp/cd-ci-glue.bash &&
+     source /tmp/cd-ci-glue.bash
    
 script:
-   - source /tmp/cd-ci-glue.bash ;
-     ( make DEBIAN_VERSION=${DIST} && 
-       is_travis_master_push && 
-       echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin && 
-       make DEBIAN_VERSION=${DIST} push ) || true
+   - (make DEBIAN_VERSION=${DIST} && 
+     is_travis_master_push && 
+     echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin && 
+     make DEBIAN_VERSION=${DIST} push) || true
 
 jobs:
   include:
     - stage: Publish project description to Docker hub
       env: DIST
       script:
-        - source /tmp/cd-ci-glue.bash &&
-          set ;
+        - set ;
           is_travis_master_push &&
           dockerhub_set_description madworx/debian-archive README.md 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ before_install:
    - source <(curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash)
      
 script:
-       make DEBIAN_VERSION=${DIST} \
-       && is_travis_master_push    \
-       && echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin \
-       && make DEBIAN_VERSION=${DIST} push
+       make DEBIAN_VERSION=${DIST} && \
+       is_travis_master_push && \
+       echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin && \
+       make DEBIAN_VERSION=${DIST} push
      done
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,5 @@ jobs:
     - stage: Publish project description to Docker hub
       env: DIST
       script:
-        - source <(curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash) && \
+        - source <(curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash) && 
           is_travis_master_push && dockerhub_set_description madworx/debian-archive README.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,12 @@ env:
     - DIST=etch
     - DIST=squeeze
 
-before_install:
-   - source <(curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash)
-     
 script:
-       make DEBIAN_VERSION=${DIST} && \
-       is_travis_master_push && \
-       echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin && \
-       make DEBIAN_VERSION=${DIST} push
-     done
+   - source <(curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash) && \
+     make DEBIAN_VERSION=${DIST} && \
+     is_travis_master_push && \
+     echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin && \
+     make DEBIAN_VERSION=${DIST} push
 
 jobs:
   include:
@@ -26,4 +23,5 @@ jobs:
       script:
         - true
       after_success:
-        - is_travis_master_push && dockerhub_set_description madworx/debian-archive README.md
+        - source <(curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash) && \
+          is_travis_master_push && dockerhub_set_description madworx/debian-archive README.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+langugage: c
+
 sudo: required
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-langugage: c
+language: c
 
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,11 @@ env:
     - DIST=etch
     - DIST=squeeze
 
+before_install:
+   - curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash > /tmp/cd-ci-glue.bash
+   
 script:
-   - source <(curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash) && 
+   - source /tmp/cd-ci-glue.bash ;
      ( make DEBIAN_VERSION=${DIST} && 
        is_travis_master_push && 
        echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin && 
@@ -23,5 +26,7 @@ jobs:
     - stage: Publish project description to Docker hub
       env: DIST
       script:
-        - curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash > cd-ci-glue.bash &&
-          source cd-ci-glue.bash && is_travis_master_push && dockerhub_set_description madworx/debian-archive README.md 
+        - source /tmp/cd-ci-glue.bash &&
+          set ;
+          is_travis_master_push &&
+          dockerhub_set_description madworx/debian-archive README.md 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ env:
     - DIST=squeeze
 
 before_install:
-   - curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash > /tmp/cd-ci-glue.bash &&
-     source /tmp/cd-ci-glue.bash
+   - source <(curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash > /tmp/cd-ci-glue.bash)
    
 script:
    - (make DEBIAN_VERSION=${DIST} && 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
      ( make DEBIAN_VERSION=${DIST} && \
        is_travis_master_push && \
        echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin && \
-       make DEBIAN_VERSION=${DIST} push ) && true
+       make DEBIAN_VERSION=${DIST} push ) || true
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ env:
     - DIST=squeeze
 
 script:
-   - make --version || true ; set ; source <(curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash) && \
-     set ; make DEBIAN_VERSION=${DIST} && \
-     is_travis_master_push && \
-     echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin && \
-     make DEBIAN_VERSION=${DIST} push
+   - source <(curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash) && \
+     ( make DEBIAN_VERSION=${DIST} && \
+       is_travis_master_push && \
+       echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin && \
+       make DEBIAN_VERSION=${DIST} push ) && true
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ jobs:
       env: DIST
       script:
         - is_travis_master_push &&
-          dockerhub_set_description madworx/debian-archive README.md 
+          dockerhub_set_description madworx/debian-archive README.md || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,5 @@ jobs:
     - stage: Publish project description to Docker hub
       env: DIST
       script:
-        - source <(curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash) && 
-          is_travis_master_push && dockerhub_set_description madworx/debian-archive README.md
+        - curl https://raw.githubusercontent.com/madworx/cd-ci-glue/master/src/cd-ci-glue.bash > cd-ci-glue.bash &&
+          source cd-ci-glue.bash && is_travis_master_push && dockerhub_set_description madworx/debian-archive README.md 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,5 @@ jobs:
     - stage: Publish project description to Docker hub
       env: DIST
       script:
-        - set ;
-          is_travis_master_push &&
+        - is_travis_master_push &&
           dockerhub_set_description madworx/debian-archive README.md 

--- a/build-archived-debian-image.sh
+++ b/build-archived-debian-image.sh
@@ -20,6 +20,7 @@ CURRENTLAST="$(docker inspect --format='{{ index .Config.Labels "last_modified_s
 
 if [ "x${CURRENTLAST}" == "x${LASTMOD}" ] ; then
     echo "Rebuild not needed - upstream has last modification ${LASTMOD}."
+    exit 1
 else
     #
     # We cannot build in one step, since the debootstrap process needs


### PR DESCRIPTION
Parallellize builds using Travis "matrix" functionality.
Test out the new cd-ci-glue library for updating the docker hub description.