### PR TITLE
stretch entering archived, add note about ExLTS still suported security

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
     - DIST=squeeze
     - DIST=wheezy
     - DIST=jessie
+    - DIST=stretch
 
 language: c
 sudo: required

--- a/README.md
+++ b/README.md
@@ -9,13 +9,19 @@ Currently, the following images are [available and automatically built on Docker
   * Debian 6 Squeeze (~2011 (Link to [debian.org](https://www.debian.org/releases/squeeze/)))
   * Debian 7 Wheezy  (~2016 (Link to [debian.org](https://www.debian.org/releases/wheezy/)))
   * Debian 8 Jessie  (~2015 (Link to [debian.org](https://www.debian.org/releases/jessie/)))
+  * Debian 9 stretch (~2017 (Link to [debian.org](https://www.debian.org/releases/stretch/)))
 
 Later releases are readily available for the [official Debian repo at Docker Hub](https://hub.docker.com/_/debian/).
 
-Please  be  aware of  the  fact  that  these images  represent  legacy
+Please  be  aware of  that  Etch to Squeeze images  represent  legacy
 versions  of   said  operating  system,  and   *do*  contain  security
 issues. Please  do not  use these  images for  anything else  than O/S
 research, testing etc.
+
+Please  be  aware of  that  since Wheezy images, images, although legacy, 
+it still has extended security support through Freexian's ExLTS service, 
+on specific (mostly server oriented) packages, for more information check 
+the page at [oficial Debian Extended Long Term Support wiki page](https://wiki.debian.org/LTS/Extended).
 
 ## Usage
 

--- a/build-archived-debian-image.sh
+++ b/build-archived-debian-image.sh
@@ -27,7 +27,7 @@ else
     # --privilege.
     #
     docker build -t debian-archived-builder . -f - <<EOF
-FROM debian:stretch-slim
+FROM debian:bookworm-slim
 RUN apt-get update && \
     apt-get install -y debootstrap
 ENTRYPOINT [ "/bin/bash", "-c" ]


### PR DESCRIPTION
* Please  be  aware of  that  since Wheezy images, images, although legacy, 
 it still has extended security support through Freexian's ExLTS service, 
 on specific (mostly server oriented) packages, for more information check 
 the page at [oficial Debian Extended Long Term Support wiki page](https://wiki.debian.org/LTS/Extended).}
* wheeze is not anymore involved in new packages but still is offered with 
 updates from frexian so those can be still used, with minor flans, check the wiki page

